### PR TITLE
Add a workflow for continuously typechecking Agda code

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: "Clone repository"
       uses: actions/checkout@v2
+      with:
+        submodules: recursive
     - name: Run Agda
       id: typecheck
       uses: ayberkt/agda-github-action@v1.2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
       uses: actions/checkout@v2
     - name: Run Agda
       id: typecheck
-      uses: ayberkt/agda-github-action@v1.1
+      uses: ayberkt/agda-github-action@v1.2
       with:
         main-file: Cat.agda
         source-dir: src

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
         submodules: recursive
     - name: Run Agda
       id: typecheck
-      uses: ayberkt/agda-github-action@v1.2
+      uses: ayberkt/agda-github-action@v1.3
       with:
         main-file: src/Cat.agda
         source-dir: .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,7 @@ jobs:
       with:
         main-file: src/Cat.agda
         source-dir: .
+        unsafe: true
     - name: Upload HTML
       id: html-upload
       uses: actions/upload-artifact@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,8 +11,8 @@ jobs:
       id: typecheck
       uses: ayberkt/agda-github-action@v1.2
       with:
-        main-file: Cat.agda
-        source-dir: src
+        main-file: src/Cat.agda
+        source-dir: .
     - name: Upload HTML
       id: html-upload
       uses: actions/upload-artifact@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,21 @@
+on: [push]
+
+jobs:
+  typechecking:
+    runs-on: ubuntu-latest
+    name: Typechecking
+    steps:
+    - name: "Clone repository"
+      uses: actions/checkout@v2
+    - name: Run Agda
+      id: typecheck
+      uses: ayberkt/agda-github-action@v1.1
+      with:
+        main-file: Cat.agda
+        source-dir: src
+    - name: Upload HTML
+      id: html-upload
+      uses: actions/upload-artifact@v1
+      with:
+        name: html
+        path: html


### PR DESCRIPTION
I recently created a [GitHub action for Agda](https://github.com/ayberkt/agda-github-action). This PR adds a workflow to this repository that runs this action upon every push.

This has two benefits:

1. It's quite useful to know that a new commit did not result in ill-typed code. Of course, it is standard practice for Agda code to be constantly typechecked when it is being edited meaning it is not very likely that commits that break the typing are introduced. However, it frequently happens that one typechecks only the module one is editing, but not the entire project whose typing might have been broken by those changes.

2. This Agda action generates HTML and makes it available as an artefact. Even if this code stops being maintained at some point, and the Agda version it uses becomes obsolete, an HTML rendering will be available for those who would like to read a syntax-highlighted and clickable rendering of the code. This point is supported by the fact that Agda code is essentially not possible to highlight without typechecking it.